### PR TITLE
Simplify Subscribers

### DIFF
--- a/src/event_manager/epoll_context.rs
+++ b/src/event_manager/epoll_context.rs
@@ -3,18 +3,19 @@ use std::os::unix::io::RawFd;
 
 use crate::epoll::{ControlOperation, Epoll, EpollEvent};
 
+use super::subscribers::SubscriberId;
 use super::{ControlOps, Error, Result};
 
 // Internal use structure that keeps the epoll related state of an EventManager.
 pub(crate) struct EpollContext {
     // The epoll wrapper.
     pub(crate) epoll: Epoll,
-    // Records the index of the subscriber associated with the given RawFd. The event event_manager
+    // Records the unique id of the subscriber associated with the given RawFd. The event_manager
     // does not currently support more than one subscriber being associated with an fd.
-    pub(crate) fd_dispatch: HashMap<RawFd, usize>,
-    // Records the set of fds that are associated with the subscriber that has the given index
-    // (this is essentially the reverse of the previous field).
-    pub(crate) subscriber_watch_list: HashMap<usize, Vec<RawFd>>,
+    pub(crate) fd_dispatch: HashMap<RawFd, SubscriberId>,
+    // Records the set of fds that are associated with the subscriber that has the given unique id
+    // (this is required to track all fds ).
+    pub(crate) subscriber_watch_list: HashMap<SubscriberId, Vec<RawFd>>,
 }
 
 impl EpollContext {
@@ -26,12 +27,12 @@ impl EpollContext {
         })
     }
 
-    // Remove the fds associated with the provided subscriber index from the epoll set and the
-    // other structures. The subscriber index must be valid.
-    pub(crate) fn remove(&mut self, subscriber_index: usize) {
+    // Remove the fds associated with the provided subscriber id from the epoll set and the
+    // other structures. The subscriber id must be valid.
+    pub(crate) fn remove(&mut self, subscriber_id: SubscriberId) {
         let fds = self
             .subscriber_watch_list
-            .remove(&subscriber_index)
+            .remove(&subscriber_id)
             .unwrap_or_else(Vec::new);
         for fd in fds {
             // We ignore the result of the operation since there's nothing we can't do, and its
@@ -43,15 +44,15 @@ impl EpollContext {
         }
     }
 
-    // Gets the index of the subscriber associated with the provided fd (if such an association
-    // exists).
-    pub(crate) fn subscriber_index(&self, fd: RawFd) -> Option<usize> {
+    // Gets the unique id of the subscriber associated with the provided fd
+    // (if such an association exists).
+    pub(crate) fn subscriber_id(&self, fd: RawFd) -> Option<SubscriberId> {
         self.fd_dispatch.get(&fd).copied()
     }
 
     // Creates and returns a ControlOps object for the subscriber associated with the provided
-    // index. The subscriber index must be valid.
-    pub(crate) fn ops_unchecked(&mut self, subscriber_index: usize) -> ControlOps {
-        ControlOps::new(self, subscriber_index)
+    // unique id. The subscriber id MUST be valid.
+    pub(crate) fn ops_unchecked(&mut self, subscriber_id: SubscriberId) -> ControlOps {
+        ControlOps::new(self, subscriber_id)
     }
 }

--- a/src/event_manager/mod.rs
+++ b/src/event_manager/mod.rs
@@ -31,9 +31,6 @@ pub type Result<T> = result::Result<T, Error>;
 /// Opaque object that uniquely represents a subscriber registered with an `EventManager`.
 #[derive(Clone, Copy, Debug)]
 pub struct SubscriberToken {
-    // We currently use a Vec to hold subscribers within the EventManager, and this is the
-    // position associated with the subscriber this token represents.
-    index: usize,
     // The unicity is ensured by using the 128bit id that's incremented on every add operation,
     // which virtually guarantees there will be no wrap-arounds or clashes.
     id: u128,

--- a/src/event_manager/mod.rs
+++ b/src/event_manager/mod.rs
@@ -31,9 +31,7 @@ pub type Result<T> = result::Result<T, Error>;
 /// Opaque object that uniquely represents a subscriber registered with an `EventManager`.
 #[derive(Clone, Copy, Debug)]
 pub struct SubscriberToken {
-    // The unicity is ensured by using the 128bit id that's incremented on every add operation,
-    // which virtually guarantees there will be no wrap-arounds or clashes.
-    id: u128,
+    id: subscribers::SubscriberId,
 }
 
 /// The `EventSubscriber` trait allows the interaction between an `EventManager` and different

--- a/src/event_manager/subscribers.rs
+++ b/src/event_manager/subscribers.rs
@@ -1,28 +1,26 @@
 use super::SubscriberToken;
 
+use std::collections::HashMap;
+
 // Internal structure used to keep the set of subscribers registered with an EventManger. The
-// current implementation uses an index in a Vec to identify a subscriber, and this implementation
+// current implementation uses an index in a HashMap to identify a subscriber, and this implementation
 // detail leaks into other internal structures/functionality (EpollContext, ControlOps, etc),
 // but is hidden with respect to the public interface of the EventManager.
 pub(crate) struct Subscribers<T> {
     // The first element of each pair, when not None, holds a subscriber, while the second
     // records its unique id.
-    subscribers: Vec<(Option<T>, u128)>,
+    subscribers: HashMap<u128, T>,
     // We are generating the unique ids by incrementing this counter for each added subscriber,
     // and rely on the extremely large value range of u128 to ensure each value is effectively
     // unique over the runtime of any VMM.
     next_token_id: u128,
-    // Whenever a subscriber is removed, we record its index as being free, so it can be reused
-    // when adding other subscribers.
-    free_sub_indices: Vec<usize>,
 }
 
 impl<T> Subscribers<T> {
     pub(crate) fn new() -> Self {
         Subscribers {
-            subscribers: Vec::new(),
+            subscribers: HashMap::new(),
             next_token_id: 0,
-            free_sub_indices: Vec::new(),
         }
     }
 
@@ -31,45 +29,20 @@ impl<T> Subscribers<T> {
         let token_id = self.next_token_id;
         self.next_token_id += 1;
 
-        let index = if let Some(idx) = self.free_sub_indices.pop() {
-            self.subscribers[idx] = (Some(subscriber), token_id);
-            idx
-        } else {
-            self.subscribers.push((Some(subscriber), token_id));
-            self.subscribers.len() - 1
-        };
+        self.subscribers.insert(token_id, subscriber);
 
-        SubscriberToken {
-            index,
-            id: token_id,
-        }
+        SubscriberToken { id: token_id }
     }
 
     // Remove and return the subscriber associated with the given token, if it exists.
     pub(crate) fn remove(&mut self, token: SubscriberToken) -> Option<T> {
-        if self.find(token).is_some() {
-            let (ref mut slot, _) = self.subscribers[token.index];
-            self.free_sub_indices.push(token.index);
-            return slot.take();
-        }
-        None
+        self.subscribers.remove(&token.id)
     }
 
-    // Return a mutable reference to the subscribers associated with the provided token, if
-    // such a subscriber exists.
-    pub(crate) fn find(&mut self, token: SubscriberToken) -> Option<&mut T> {
-        let (maybe_sub, token_id) = self.subscribers.get_mut(token.index)?;
-        if *token_id != token.id {
-            return None;
-        }
-        maybe_sub.as_mut()
-    }
-
-    // Return a mutable reference to the subscriber present at the given index in the inner Vec.
+    // Return a mutable reference to the subscriber present at the given index in the inner HashMap.
     // This method should only be called for indices that are known to be valid, otherwise
     // panics can occur.
-    pub(crate) fn get_mut(&mut self, index: usize) -> &mut T {
-        // We use unwrap here because we know the index is valid.
-        self.subscribers[index].0.as_mut().unwrap()
+    pub(crate) fn get_mut(&mut self, token: SubscriberToken) -> Option<&mut T> {
+        self.subscribers.get_mut(&token.id)
     }
 }

--- a/src/event_manager/subscribers.rs
+++ b/src/event_manager/subscribers.rs
@@ -1,19 +1,23 @@
-use super::SubscriberToken;
-
 use std::collections::HashMap;
+use std::ops::Add;
+
+// Unique subscriber id type.
+// The uniqueness is ensured by using the 128bit id that's incremented on every add operation,
+// which virtually guarantees there will be no wrap-arounds or clashes.
+pub(crate) type SubscriberId = u128;
 
 // Internal structure used to keep the set of subscribers registered with an EventManger. The
-// current implementation uses an index in a HashMap to identify a subscriber, and this implementation
-// detail leaks into other internal structures/functionality (EpollContext, ControlOps, etc),
-// but is hidden with respect to the public interface of the EventManager.
+// current implementation uses a unique id in a HashMap to identify a subscriber, and this
+// implementation detail leaks into other internal structures/functionality (EpollContext,
+// ControlOps, etc), but is hidden with respect to the public interface of the EventManager.
 pub(crate) struct Subscribers<T> {
     // The first element of each pair, when not None, holds a subscriber, while the second
     // records its unique id.
-    subscribers: HashMap<u128, T>,
+    subscribers: HashMap<SubscriberId, T>,
     // We are generating the unique ids by incrementing this counter for each added subscriber,
     // and rely on the extremely large value range of u128 to ensure each value is effectively
     // unique over the runtime of any VMM.
-    next_token_id: u128,
+    next_token_id: SubscriberId,
 }
 
 impl<T> Subscribers<T> {
@@ -25,24 +29,22 @@ impl<T> Subscribers<T> {
     }
 
     // Adds a subscriber and generates an unique token to represent it.
-    pub(crate) fn add(&mut self, subscriber: T) -> SubscriberToken {
+    pub(crate) fn add(&mut self, subscriber: T) -> SubscriberId {
         let token_id = self.next_token_id;
-        self.next_token_id += 1;
-
+        self.next_token_id = self.next_token_id.add(1);
         self.subscribers.insert(token_id, subscriber);
-
-        SubscriberToken { id: token_id }
+        token_id
     }
 
     // Remove and return the subscriber associated with the given token, if it exists.
-    pub(crate) fn remove(&mut self, token: SubscriberToken) -> Option<T> {
-        self.subscribers.remove(&token.id)
+    pub(crate) fn remove(&mut self, id: SubscriberId) -> Option<T> {
+        self.subscribers.remove(&id)
     }
 
-    // Return a mutable reference to the subscriber present at the given index in the inner HashMap.
-    // This method should only be called for indices that are known to be valid, otherwise
+    // Return a mutable reference to the subscriber indexed with the given id in the inner HashMap.
+    // This method should only be called for ids that are known to be valid, otherwise
     // panics can occur.
-    pub(crate) fn get_mut(&mut self, token: SubscriberToken) -> Option<&mut T> {
-        self.subscribers.get_mut(&token.id)
+    pub(crate) fn get_mut(&mut self, id: SubscriberId) -> Option<&mut T> {
+        self.subscribers.get_mut(&id)
     }
 }


### PR DESCRIPTION
What do you think of replacing the anti-pattern code in `Subscribers` with a simple to use and understand `HashMap`?

Instead of having `HashMap<RawFd, usize>` to get the index in vector: `Vec<(Option<T>, u128)>` this PR proposes: `HashMap<RawFd, SubscriberUniqueId>` + `HashMap<SubscriberUniqueId, T>`.

The PR also simplifies the opaque `SubscriberToken` to only hold the subscriber unique id and not also a index in the original vector.

The `Subscribers` interface (only crate-level visibility) was also changed to not care about `SubscriberToken`s since those can be handled by the `SubscriberOps` trait implementation where they are necessary.